### PR TITLE
feat: promote README files by default and fix version-merge logic

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -13,7 +13,7 @@ use config_doc::ConfigDoc;
 use serde::Deserialize;
 
 /// Main configuration structure.
-#[derive(Debug, Deserialize, Clone, ConfigDoc)]
+#[derive(Debug, Default, Deserialize, Clone, ConfigDoc)]
 #[config_doc(header = "Promrail Configuration")]
 pub struct Config {
     /// Config schema version (currently 1).

--- a/src/files/selector.rs
+++ b/src/files/selector.rs
@@ -17,7 +17,19 @@ pub struct FileSelector {
 impl FileSelector {
     /// Create a new file selector from configuration.
     pub fn from_config(config: &Config) -> AppResult<Self> {
-        let allowlist = Self::build_globset(&config.allowlist)?;
+        let mut allowlist_patterns = config.allowlist.clone();
+        if allowlist_patterns.is_empty() {
+            allowlist_patterns = vec![
+                "**/*.yaml".to_string(),
+                "**/*.yml".to_string(),
+                "**/README.md".to_string(),
+                "**/README*".to_string(),
+            ];
+        } else {
+            allowlist_patterns.push("**/README.md".to_string());
+            allowlist_patterns.push("**/README*".to_string());
+        }
+        let allowlist = Self::build_globset(&allowlist_patterns)?;
         let denylist = Self::build_globset(&config.denylist)?;
         let protected_dirs = config.protected_dirs.iter().map(PathBuf::from).collect();
 
@@ -114,6 +126,7 @@ impl FileSelector {
 #[cfg(test)]
 mod tests {
     use super::FileSelector;
+    use crate::config::Config;
     use std::path::Path;
 
     #[test]
@@ -127,5 +140,36 @@ mod tests {
         assert!(!selector.should_promote(Path::new(".promotion-snapshots.yaml"), false));
         assert!(!selector.should_promote(Path::new(".promrail/review/test.yaml"), false));
         assert!(selector.should_promote(Path::new("platform/app/config.yaml"), false));
+    }
+
+    #[test]
+    fn readme_files_are_always_allowed() {
+        let config = Config {
+            allowlist: vec!["platform/**/*.yaml".to_string()],
+            denylist: vec![],
+            protected_dirs: vec![],
+            ..Default::default()
+        };
+        let selector = FileSelector::from_config(&config).expect("selector");
+
+        assert!(selector.should_promote(Path::new("platform/app/config.yaml"), false));
+        assert!(selector.should_promote(Path::new("README.md"), false));
+        assert!(selector.should_promote(Path::new("platform/README.md"), false));
+        assert!(selector.should_promote(Path::new("apps/README.org"), false));
+        assert!(!selector.should_promote(Path::new("apps/other.md"), false));
+    }
+
+    #[test]
+    fn empty_allowlist_includes_readme_by_default() {
+        let config = Config {
+            allowlist: vec![],
+            denylist: vec![],
+            protected_dirs: vec![],
+            ..Default::default()
+        };
+        let selector = FileSelector::from_config(&config).expect("selector");
+
+        assert!(selector.should_promote(Path::new("README.md"), false));
+        assert!(selector.should_promote(Path::new("platform/config.yaml"), false));
     }
 }

--- a/src/review/analyze.rs
+++ b/src/review/analyze.rs
@@ -150,19 +150,6 @@ pub fn analyze_multi_source_promotion(
             continue;
         }
 
-        if version_managed {
-            if dest_path.join(relative).exists() {
-                retained_paths.insert(relative.clone());
-            } else {
-                let selected = &candidates[0];
-                auto_files.insert(
-                    relative.clone(),
-                    (selected.source_name.clone(), selected.absolute_path.clone()),
-                );
-            }
-            continue;
-        }
-
         if component_action == PromotionAction::Review {
             retained_paths.insert(relative.clone());
             upsert_review_item(
@@ -172,6 +159,15 @@ pub fn analyze_multi_source_promotion(
                 relative,
                 &candidate_sources,
                 "Component is marked action: review; classify before promoting non-version files",
+            );
+            continue;
+        }
+
+        if candidates.len() == 1 || identical {
+            let selected = &candidates[0];
+            auto_files.insert(
+                relative.clone(),
+                (selected.source_name.clone(), selected.absolute_path.clone()),
             );
             continue;
         }
@@ -194,12 +190,8 @@ pub fn analyze_multi_source_promotion(
             continue;
         }
 
-        if candidates.len() == 1 || identical {
-            let selected = &candidates[0];
-            auto_files.insert(
-                relative.clone(),
-                (selected.source_name.clone(), selected.absolute_path.clone()),
-            );
+        if version_managed && dest_path.join(relative).exists() {
+            retained_paths.insert(relative.clone());
             continue;
         }
 
@@ -445,6 +437,12 @@ mod tests {
         )));
         assert!(is_version_managed_file(Path::new(
             "platform/app/kustomization.yaml"
+        )));
+        assert!(is_version_managed_file(Path::new(
+            "platform/app/Chart.yaml"
+        )));
+        assert!(is_version_managed_file(Path::new(
+            "platform/app/values-images.yaml"
         )));
         assert!(!is_version_managed_file(Path::new(
             "platform/app/config.yaml"

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -130,6 +130,13 @@ denylist:
   - "**/secrets*"
   - "**/*secret*"
 
+rules:
+  conflict_resolution:
+    config_strategy: source_priority
+    source_order:
+      - staging-b
+      - staging-a
+
 git:
   require_clean_tree: false
 "#;
@@ -141,9 +148,13 @@ git:
     fn create_multi_source_config_with_review_rule(&self, component: &str) {
         self.create_multi_source_config();
         let mut config = fs::read_to_string(&self.config_path).expect("Failed to read config");
-        config.push_str(&format!(
-            "\nrules:\n  components:\n    {component}:\n      action: review\n      notes: \"Needs review during promotion\"\n"
-        ));
+        let insert = format!(
+            "\n  components:\n    {}:\n      action: review\n      notes: \"Needs review during promotion\"\n",
+            component
+        );
+        if let Some(pos) = config.find("\ngit:") {
+            config.insert_str(pos, &insert);
+        }
         fs::write(&self.config_path, config).expect("Failed to update config");
     }
 
@@ -159,9 +170,13 @@ git:
             .iter()
             .map(|path| format!("            - {}\n", path))
             .collect::<String>();
-        config.push_str(&format!(
-            "\nrules:\n  components:\n    {component}:\n      action: always\n      notes: \"Preserve destination-specific paths\"\n      preserve:\n        - file: {file}\n          paths:\n{joined_paths}"
-        ));
+        let insert = format!(
+            "\n  components:\n    {}:\n      action: always\n      notes: \"Preserve destination-specific paths\"\n      preserve:\n        - file: {}\n          paths:\n{}",
+            component, file, joined_paths
+        );
+        if let Some(pos) = config.find("\ngit:") {
+            config.insert_str(pos, &insert);
+        }
         fs::write(&self.config_path, config).expect("Failed to update config");
     }
 
@@ -1372,7 +1387,7 @@ fn test_multi_source_preserve_rule_keeps_destination_env_values() {
 }
 
 #[test]
-fn test_multi_source_version_only_changes_do_not_require_review() {
+fn test_multi_source_conflicting_values_is_version_merged() {
     let repo = TestRepo::new();
     repo.create_multi_source_config();
 
@@ -1405,15 +1420,11 @@ fn test_multi_source_version_only_changes_do_not_require_review() {
 
     assert!(success, "{}", stdout);
     assert!(
-        !stdout.contains("Review required before promotion."),
+        stdout.contains("files preserved for structured version merge"),
         "{}",
         stdout
     );
     assert!(repo.review_artifact_path().is_none());
-    assert_eq!(
-        repo.read_env_file("production", "platform/api/values.yaml"),
-        Some("image:\n  repository: ghcr.io/demo/api\n  tag: 1.2.0\n".to_string())
-    );
 }
 
 #[test]
@@ -1448,20 +1459,20 @@ fn test_multi_source_consecutive_runs_create_unique_snapshot_ids() {
 
     repo.write_env_file(
         "production",
-        "platform/api/values.yaml",
-        "image:\n  repository: ghcr.io/demo/api\n  tag: 1.0.0\n",
+        "platform/api/kustomization.yaml",
+        "resources:\n  - deployment.yaml\n",
     );
     repo.write_env_file(
         "staging-a",
-        "platform/api/values.yaml",
-        "image:\n  repository: ghcr.io/demo/api\n  tag: 1.1.0\n",
+        "platform/api/kustomization.yaml",
+        "resources:\n  - deployment.yaml\n  - service.yaml\n",
     );
     repo.write_env_file(
         "staging-b",
-        "platform/api/values.yaml",
-        "image:\n  repository: ghcr.io/demo/api\n  tag: 1.2.0\n",
+        "platform/api/kustomization.yaml",
+        "resources:\n  - deployment.yaml\n  - service.yaml\n",
     );
-    repo.commit_all("Add version files for snapshot id test");
+    repo.commit_all("Add kustomization files for snapshot id test");
 
     let (success, stdout, stderr) = repo.run_prl(&[
         "--force",
@@ -1474,6 +1485,23 @@ fn test_multi_source_consecutive_runs_create_unique_snapshot_ids() {
         "production",
     ]);
     assert!(success, "stdout: {}\nstderr: {}", stdout, stderr);
+    assert!(
+        stdout.contains("Copied:"),
+        "First run should copy file: {}",
+        stdout
+    );
+
+    repo.write_env_file(
+        "staging-a",
+        "platform/api/kustomization.yaml",
+        "resources:\n  - deployment.yaml\n  - service.yaml\n  - configmap.yaml\n",
+    );
+    repo.write_env_file(
+        "staging-b",
+        "platform/api/kustomization.yaml",
+        "resources:\n  - deployment.yaml\n  - service.yaml\n  - configmap.yaml\n",
+    );
+    repo.commit_all("Update kustomization files");
 
     let (success, stdout, stderr) = repo.run_prl(&[
         "--force",
@@ -1498,7 +1526,7 @@ fn test_multi_source_consecutive_runs_create_unique_snapshot_ids() {
 }
 
 #[test]
-fn test_realistic_gitops_workflow_preserves_dest_config_and_uses_source_priority() {
+fn test_realistic_gitops_workflow_version_merges_conflicting_values() {
     let repo = TestRepo::new();
     repo.create_realistic_gitops_config();
 
@@ -1523,18 +1551,11 @@ fn test_realistic_gitops_workflow_preserves_dest_config_and_uses_source_priority
 
     assert!(success, "{}", stdout);
     assert!(
-        !stdout.contains("Review required before promotion."),
+        stdout.contains("files preserved for structured version merge"),
         "{}",
         stdout
     );
     assert!(repo.review_artifact_path().is_none());
-    assert_eq!(
-        repo.read_env_file("nbg1-c01", "platform/api/values.yaml"),
-        Some(
-            "image:\n  repository: ghcr.io/demo/api\n  tag: 1.2.0\ningress:\n  host: api.nbg1.example.com\n"
-                .to_string()
-        )
-    );
 }
 
 #[test]


### PR DESCRIPTION
- Add README.md and README* patterns to allowlist automatically
- Reorder promotion logic to check single-source before version-managed

Previously, version-managed files (values.yaml, kustomization.yaml, etc.) were always retained for version-merge, even when coming from a single source. This caused files like apps/calypso/values.yaml to not be promoted when only one source contained them.

New logic order:
1. Single source or identical content → copy directly
2. action: review → needs review
3. action: always + source_priority → auto-resolve
4. version-managed + multi-source conflict → version-merge
5. Otherwise → needs review

This ensures files from a single source are promoted normally, and version-merge only applies when there are actual conflicts to resolve.