### PR TITLE
release: Version 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.3.1](https://github.com/forkline/prl/tree/v0.3.1) - 2026-03-27
+
+### Build
+
+- Vendor libgit2 for release binaries (#17) ([f88d6c8](https://github.com/forkline/prl/commit/f88d6c85ca78ff7b0652f2c9fcbcef8a9159c707))
+
 ## [v0.3.0](https://github.com/forkline/prl/tree/v0.3.0) - 2026-03-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "promrail"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "promrail"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 authors = ["Pando85 <pando855@gmail.com>"]
 description = "Git-native GitOps promotion tool"


### PR DESCRIPTION
## Summary

- Bump version from 0.3.0 to 0.3.1
- Update changelog with build system change (vendor libgit2 for release binaries)

## Changes

This is a patch release with an internal build system change:
- Vendored libgit2 for release binaries to improve build reliability

## Checklist

- [x] Version bumped in Cargo.toml
- [x] Cargo.lock updated
- [x] Changelog updated