### PR TITLE
feat: structured version updates for single-source promotions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Structured version updates for single-source promotions - version-managed files (kustomization.yaml, Chart.yaml, values.yaml) now use structured updates that preserve destination-specific content while updating versions
+- `version_handling` option in component rules to override structured update behavior (`whole_file` to force wholesale copy)
+
+### Changed
+
+- Version-managed files in single-source promotions are no longer wholesale copied; only version fields are updated from source, preserving destination configuration
+
 ## [v0.3.1](https://github.com/forkline/prl/tree/v0.3.1) - 2026-03-27
 
 ### Build

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -867,6 +867,56 @@ Recommended workflow with a coding agent:
 3. ask the agent to add `preserve` rules for those paths in `promrail.yaml`
 4. rerun `prl`; future promotions keep those destination paths automatically
 
+### Version-Managed File Handling
+
+Version-managed files (`kustomization.yaml`, `Chart.yaml`, `values.yaml`) receive special treatment during promotion:
+
+**Structured Version Updates**: When a version-managed file exists in the destination, promrail uses structured updates instead of wholesale copies:
+- Only version fields (helm chart versions, container image tags) are updated from source
+- All other content (resources, patches, env-specific config) is preserved from destination
+- This applies to both single-source and multi-source promotions
+
+**Example**: `kustomization.yaml` in source has:
+```yaml
+helmCharts:
+  - name: kube-prometheus-stack
+    version: 82.15.1
+resources:
+  - resources/homelab-specific.yaml
+```
+
+Destination has:
+```yaml
+helmCharts:
+  - name: kube-prometheus-stack
+    version: 82.10.4
+resources:
+  - resources/etcd-secrets-updater.yaml
+```
+
+After promotion, destination becomes:
+```yaml
+helmCharts:
+  - name: kube-prometheus-stack
+    version: 82.15.1  # Updated from source
+resources:
+  - resources/etcd-secrets-updater.yaml  # Preserved from destination
+```
+
+**Override with `version_handling`**: To force wholesale copy for specific components:
+
+```yaml
+rules:
+  components:
+    platform/special-case:
+      action: always
+      version_handling: whole_file  # Copy entire file instead of structured update
+```
+
+**When to use `version_handling: whole_file`**:
+- Component has no version information but uses version-managed filename
+- You want complete replacement of destination file
+
 ### Post-Promotion Rule Tuning
 
 When `prl --force` still leaves environment-specific changes in the diff, the recommended loop is:

--- a/src/commands/promote.rs
+++ b/src/commands/promote.rs
@@ -8,7 +8,7 @@ use log::{debug, info, warn};
 
 use crate::commands::diff::{self, DiffArgs};
 use crate::commands::{default_filter, print_promotion_summary};
-use crate::config::{Config, PromotionAction};
+use crate::config::{Config, PromotionAction, VersionHandling};
 use crate::error::{AppResult, PromrailError};
 use crate::files::{FileDiscovery, FileSelector};
 use crate::git::GitRepo;
@@ -184,6 +184,22 @@ fn execute_single_source(config: &Config, repo: &GitRepo, args: &PromoteArgs) ->
         return Ok(());
     }
 
+    // Separate version-managed files from regular copies
+    // Version-managed files use structured updates unless version_handling: whole_file
+    let (version_managed_copies, regular_copies): (Vec<_>, Vec<_>) =
+        result.copied.into_iter().partition(|f| {
+            if !is_version_managed_file(&f.path) || !dest_path.join(&f.path).exists() {
+                return false;
+            }
+            // Check for version_handling override
+            let component = get_component(&f.path);
+            let component_rule = config.rules.get_component_rule(&component);
+            let use_whole_file = component_rule
+                .map(|r| r.version_handling == VersionHandling::WholeFile)
+                .unwrap_or(false);
+            !use_whole_file
+        });
+
     if args.dry_run {
         info!("Dry run complete. No files were modified.");
         return Ok(());
@@ -196,7 +212,8 @@ fn execute_single_source(config: &Config, repo: &GitRepo, args: &PromoteArgs) ->
 
     info!("Applying changes...");
 
-    for file_diff in &result.copied {
+    // Copy regular files
+    for file_diff in &regular_copies {
         let source_file = source_path.join(&file_diff.path);
         let dest_file = dest_path.join(&file_diff.path);
 
@@ -205,6 +222,56 @@ fn execute_single_source(config: &Config, repo: &GitRepo, args: &PromoteArgs) ->
             "{}",
             style(format!("Copied: {}", file_diff.path.display())).green()
         );
+    }
+
+    // Apply structured version updates for version-managed files
+    if !version_managed_copies.is_empty() {
+        let components: Vec<String> = version_managed_copies
+            .iter()
+            .map(|f| get_component(&f.path))
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
+
+        let report = versions::extract_versions(&source_path, &[])?;
+        let apply_result = versions::apply_versions(
+            &report,
+            &dest_path,
+            &versions::ApplyOptions {
+                components,
+                dry_run: false,
+                check_conflicts: false,
+                create_snapshot: false,
+            },
+        )?;
+
+        for updated in &apply_result.updated_files {
+            println!(
+                "{}",
+                style(format!(
+                    "Updated versions: {}",
+                    updated
+                        .strip_prefix(&dest_path)
+                        .unwrap_or(updated)
+                        .display()
+                ))
+                .cyan()
+            );
+        }
+
+        // Copy version-managed files that had no version changes
+        for file_diff in &version_managed_copies {
+            let updated_path = dest_path.join(&file_diff.path);
+            if !apply_result.updated_files.contains(&updated_path) {
+                let source_file = source_path.join(&file_diff.path);
+                let dest_file = dest_path.join(&file_diff.path);
+                repo.copy_file(&source_file, &dest_file)?;
+                println!(
+                    "{}",
+                    style(format!("Copied: {}", file_diff.path.display())).green()
+                );
+            }
+        }
     }
 
     if should_delete {
@@ -217,7 +284,7 @@ fn execute_single_source(config: &Config, repo: &GitRepo, args: &PromoteArgs) ->
 
     println!();
     println!("{}", style("Promotion complete!").bold());
-    print_promotion_summary(result.copied.len(), result.deleted.len(), should_delete);
+    print_promotion_summary(regular_copies.len(), result.deleted.len(), should_delete);
 
     Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -211,6 +211,26 @@ impl std::fmt::Display for PromotionAction {
     }
 }
 
+/// Version handling strategy for version-managed files.
+#[derive(Debug, Deserialize, Clone, Default, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum VersionHandling {
+    /// Use structured version updates, preserve destination content.
+    #[default]
+    Structured,
+    /// Copy entire file from source (override for special cases).
+    WholeFile,
+}
+
+impl std::fmt::Display for VersionHandling {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VersionHandling::Structured => write!(f, "structured"),
+            VersionHandling::WholeFile => write!(f, "whole_file"),
+        }
+    }
+}
+
 /// Component-level promotion rule.
 #[derive(Debug, Deserialize, Clone, ConfigDoc)]
 pub struct ComponentRule {
@@ -226,6 +246,10 @@ pub struct ComponentRule {
     /// Preserve destination-specific configuration paths for matching files.
     #[serde(default)]
     pub preserve: Vec<PreserveRule>,
+
+    /// Override version-managed file handling strategy.
+    #[serde(default)]
+    pub version_handling: VersionHandling,
 }
 
 /// File-specific preserve rule for YAML/JSON promotion.

--- a/src/review/analyze.rs
+++ b/src/review/analyze.rs
@@ -5,7 +5,9 @@ use std::path::{Path, PathBuf};
 use crate::commands::promote::{
     PromoteArgs, component_exists_in_dest, get_component, is_protected,
 };
-use crate::config::{ComponentRule, Config, ConfigStrategy, PromotionAction, PromotionRules};
+use crate::config::{
+    ComponentRule, Config, ConfigStrategy, PromotionAction, PromotionRules, VersionHandling,
+};
 use crate::error::AppResult;
 use crate::files::{FileDiscovery, FileSelector};
 use crate::review::models::{
@@ -165,6 +167,20 @@ pub fn analyze_multi_source_promotion(
 
         if candidates.len() == 1 || identical {
             let selected = &candidates[0];
+
+            // Version-managed files that exist in destination use structured updates
+            // unless explicitly overridden to whole_file
+            if version_managed && dest_path.join(relative).exists() {
+                let use_whole_file = component_rule
+                    .map(|r| r.version_handling == VersionHandling::WholeFile)
+                    .unwrap_or(false);
+
+                if !use_whole_file {
+                    retained_paths.insert(relative.clone());
+                    continue;
+                }
+            }
+
             auto_files.insert(
                 relative.clone(),
                 (selected.source_name.clone(), selected.absolute_path.clone()),
@@ -183,6 +199,20 @@ pub fn analyze_multi_source_promotion(
                 .iter()
                 .find(|candidate| candidate.source_name == selected_source)
                 .unwrap_or(&candidates[0]);
+
+            // Version-managed files that exist in destination use structured updates
+            // unless explicitly overridden to whole_file
+            if version_managed && dest_path.join(relative).exists() {
+                let use_whole_file = component_rule
+                    .map(|r| r.version_handling == VersionHandling::WholeFile)
+                    .unwrap_or(false);
+
+                if !use_whole_file {
+                    retained_paths.insert(relative.clone());
+                    continue;
+                }
+            }
+
             auto_files.insert(
                 relative.clone(),
                 (selected.source_name.clone(), selected.absolute_path.clone()),
@@ -191,8 +221,14 @@ pub fn analyze_multi_source_promotion(
         }
 
         if version_managed && dest_path.join(relative).exists() {
-            retained_paths.insert(relative.clone());
-            continue;
+            let use_whole_file = component_rule
+                .map(|r| r.version_handling == VersionHandling::WholeFile)
+                .unwrap_or(false);
+
+            if !use_whole_file {
+                retained_paths.insert(relative.clone());
+                continue;
+            }
         }
 
         retained_paths.insert(relative.clone());

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1485,9 +1485,10 @@ fn test_multi_source_consecutive_runs_create_unique_snapshot_ids() {
         "production",
     ]);
     assert!(success, "stdout: {}\nstderr: {}", stdout, stderr);
+    // kustomization.yaml is version-managed, so it uses structured updates
     assert!(
-        stdout.contains("Copied:"),
-        "First run should copy file: {}",
+        stdout.contains("files preserved for structured version merge"),
+        "First run should preserve file for structured update: {}",
         stdout
     );
 
@@ -1844,6 +1845,314 @@ fn test_overwrite_same_content_no_change() {
     assert_eq!(
         repo.read_production_file("platform/config.yaml"),
         Some(content.to_string())
+    );
+}
+
+// =============================================================================
+// SINGLE-SOURCE VERSION-MANAGED FILE TESTS
+// =============================================================================
+
+#[test]
+fn test_single_source_kustomization_yaml_uses_structured_version_update() {
+    let repo = TestRepo::new();
+    repo.create_config();
+
+    // Destination has kustomization.yaml with version 1.0.0 and env-specific resources
+    repo.write_production_file(
+        "platform/monitoring/kustomization.yaml",
+        r#"helmCharts:
+  - name: kube-prometheus-stack
+    version: 1.0.0
+    repo: https://prometheus-community.github.io/helm-charts
+resources:
+  - resources/etcd-secrets-updater.yaml
+  - resources/env-specific-config.yaml
+"#,
+    );
+
+    // Source has kustomization.yaml with version 2.0.0 and different resources
+    repo.write_staging_file(
+        "platform/monitoring/kustomization.yaml",
+        r#"helmCharts:
+  - name: kube-prometheus-stack
+    version: 2.0.0
+    repo: https://prometheus-community.github.io/helm-charts
+resources:
+  - resources/homelab-specific.yaml
+"#,
+    );
+    repo.commit_all("Add kustomization files");
+
+    let (success, stdout, _stderr) =
+        repo.run_prl(&["promote", "--source", "staging", "--dest", "production"]);
+
+    assert!(success, "{}", stdout);
+    // Version-managed files use structured updates
+    assert!(
+        stdout.contains("Updated versions: platform/monitoring/kustomization.yaml"),
+        "Expected structured update message in stdout: {}",
+        stdout
+    );
+
+    // Version should be updated, but resources should be preserved from destination
+    let result = repo
+        .read_production_file("platform/monitoring/kustomization.yaml")
+        .expect("File should exist");
+    assert!(
+        result.contains("version: 2.0.0"),
+        "Version should be updated: {}",
+        result
+    );
+    assert!(
+        result.contains("resources/etcd-secrets-updater.yaml"),
+        "Destination resources should be preserved: {}",
+        result
+    );
+    assert!(
+        !result.contains("resources/homelab-specific.yaml"),
+        "Source resources should NOT be added: {}",
+        result
+    );
+}
+
+#[test]
+fn test_single_source_chart_yaml_uses_structured_version_update() {
+    let repo = TestRepo::new();
+    repo.create_config();
+
+    // Destination has Chart.yaml with version 1.0.0 and env-specific config
+    repo.write_production_file(
+        "apps/myapp/Chart.yaml",
+        r#"apiVersion: v2
+name: myapp
+version: 1.0.0
+dependencies:
+  - name: redis
+    version: 10.0.0
+    repository: https://charts.bitnami.com/bitnami
+"#,
+    );
+
+    // Source has Chart.yaml with updated redis version
+    repo.write_staging_file(
+        "apps/myapp/Chart.yaml",
+        r#"apiVersion: v2
+name: myapp
+version: 1.0.0
+dependencies:
+  - name: redis
+    version: 11.0.0
+    repository: https://charts.bitnami.com/bitnami
+"#,
+    );
+    repo.commit_all("Add Chart files");
+
+    let (success, stdout, _stderr) =
+        repo.run_prl(&["promote", "--source", "staging", "--dest", "production"]);
+
+    assert!(success, "{}", stdout);
+    // Version-managed files use structured updates
+    assert!(
+        stdout.contains("Updated versions: apps/myapp/Chart.yaml"),
+        "Expected structured update message in stdout: {}",
+        stdout
+    );
+
+    let result = repo
+        .read_production_file("apps/myapp/Chart.yaml")
+        .expect("File should exist");
+    assert!(
+        result.contains("version: 11.0.0"),
+        "Redis version should be updated: {}",
+        result
+    );
+}
+
+#[test]
+fn test_version_handling_whole_file_override() {
+    let repo = TestRepo::new();
+
+    // Create config with version_handling override
+    let config = r#"
+version: 1
+
+repos:
+  test:
+    path: .
+    environments:
+      staging:
+        path: staging
+      production:
+        path: production
+
+default_repo: test
+
+protected_dirs:
+  - custom
+  - env
+
+allowlist:
+  - "**/*.yaml"
+
+rules:
+  components:
+    platform/monitoring:
+      action: always
+      version_handling: whole_file
+
+git:
+  require_clean_tree: false
+"#;
+    fs::write(&repo.config_path, config).expect("Failed to write config");
+
+    // Destination has kustomization.yaml with version 1.0.0 and env-specific resources
+    repo.write_production_file(
+        "platform/monitoring/kustomization.yaml",
+        r#"helmCharts:
+  - name: kube-prometheus-stack
+    version: 1.0.0
+resources:
+  - resources/etcd-secrets-updater.yaml
+"#,
+    );
+
+    // Source has kustomization.yaml with version 2.0.0 and different resources
+    repo.write_staging_file(
+        "platform/monitoring/kustomization.yaml",
+        r#"helmCharts:
+  - name: kube-prometheus-stack
+    version: 2.0.0
+resources:
+  - resources/homelab-specific.yaml
+"#,
+    );
+    repo.commit_all("Add kustomization files");
+
+    let (success, stdout, _stderr) =
+        repo.run_prl(&["promote", "--source", "staging", "--dest", "production"]);
+
+    assert!(success, "{}", stdout);
+
+    // With whole_file override, entire file should be copied
+    let result = repo
+        .read_production_file("platform/monitoring/kustomization.yaml")
+        .expect("File should exist");
+    assert!(
+        result.contains("version: 2.0.0"),
+        "Version should be updated: {}",
+        result
+    );
+    assert!(
+        result.contains("resources/homelab-specific.yaml"),
+        "Source resources should be copied with whole_file: {}",
+        result
+    );
+    assert!(
+        !result.contains("resources/etcd-secrets-updater.yaml"),
+        "Destination resources should be replaced with whole_file: {}",
+        result
+    );
+}
+
+#[test]
+fn test_single_source_values_yaml_uses_structured_version_update() {
+    let repo = TestRepo::new();
+    repo.create_config();
+
+    // Destination has values.yaml with image tag 1.0.0 and env-specific ingress
+    repo.write_production_file(
+        "platform/api/values.yaml",
+        r#"image:
+  repository: ghcr.io/demo/api
+  tag: 1.0.0
+ingress:
+  host: api.prod.example.com
+  annotations:
+    external-dns.alpha.kubernetes.io/target: prod.example.com
+"#,
+    );
+
+    // Source has values.yaml with image tag 2.0.0 and different ingress
+    repo.write_staging_file(
+        "platform/api/values.yaml",
+        r#"image:
+  repository: ghcr.io/demo/api
+  tag: 2.0.0
+ingress:
+  host: api.staging.example.com
+  annotations:
+    external-dns.alpha.kubernetes.io/target: staging.example.com
+"#,
+    );
+    repo.commit_all("Add values files");
+
+    let (success, stdout, _stderr) =
+        repo.run_prl(&["promote", "--source", "staging", "--dest", "production"]);
+
+    assert!(success, "{}", stdout);
+    // Version-managed files use structured updates
+    assert!(
+        stdout.contains("Updated versions: platform/api/values.yaml"),
+        "Expected structured update message in stdout: {}",
+        stdout
+    );
+
+    let result = repo
+        .read_production_file("platform/api/values.yaml")
+        .expect("File should exist");
+    assert!(
+        result.contains("tag: 2.0.0"),
+        "Image tag should be updated: {}",
+        result
+    );
+    assert!(
+        result.contains("api.prod.example.com"),
+        "Destination ingress host should be preserved: {}",
+        result
+    );
+    assert!(
+        !result.contains("api.staging.example.com"),
+        "Source ingress host should NOT be copied: {}",
+        result
+    );
+}
+
+#[test]
+fn test_new_component_kustomization_is_whole_file_copied() {
+    // New components (not existing in destination) should still be whole-file copied
+    let repo = TestRepo::new();
+    repo.create_config();
+
+    // Source has a new component with kustomization.yaml
+    repo.write_staging_file(
+        "platform/new-service/kustomization.yaml",
+        r#"helmCharts:
+  - name: myapp
+    version: 1.0.0
+resources:
+  - resources/deployment.yaml
+"#,
+    );
+    repo.commit_all("Add new service");
+
+    let (success, stdout, _stderr) =
+        repo.run_prl(&["promote", "--source", "staging", "--dest", "production"]);
+
+    assert!(success, "{}", stdout);
+
+    // New component should be copied entirely (structured update only applies to existing files)
+    let result = repo
+        .read_production_file("platform/new-service/kustomization.yaml")
+        .expect("File should exist");
+    assert!(
+        result.contains("version: 1.0.0"),
+        "Version should be present: {}",
+        result
+    );
+    assert!(
+        result.contains("resources/deployment.yaml"),
+        "Resources should be copied for new component: {}",
+        result
     );
 }
 


### PR DESCRIPTION
- Version-managed files (kustomization.yaml, Chart.yaml, values.yaml) now use structured updates instead of wholesale copies
- Only version fields are updated from source, preserving destination content (resources, patches, env-specific config)
- Add version_handling option to component rules to override behavior
- Works for both single-source and multi-source promotions
- Add comprehensive e2e tests for the new behavior