### PR TITLE
chore: improve release script and update release skill

### DIFF
--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -1,22 +1,75 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
-if ! [ "$(git rev-list --count origin/main..HEAD)" -eq 0 ]; then
-    echo "There are commits in this branch. Please merge them first."
-    echo "CHANGELOG template needs main commit ID."
-    exit 1
+ensure_full_history() {
+    if git rev-parse --is-shallow-repository 2>/dev/null | grep -q "true"; then
+        echo "Shallow clone detected. Fetching full history..."
+        git fetch --unshallow --quiet
+    fi
+    echo "Fetching tags..."
+    git fetch --tags --quiet
+}
+
+ensure_clean_state() {
+    if ! git diff --quiet || ! git diff --cached --quiet; then
+        echo "Working tree is not clean. Commit or stash changes first."
+        exit 1
+    fi
+
+    BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    if [ "$BRANCH" != "main" ]; then
+        echo "Not on main branch. Current branch: $BRANCH"
+        exit 1
+    fi
+
+    git pull origin main --quiet
+
+    if [ "$(git rev-list --count origin/main..HEAD 2>/dev/null || echo 1)" -ne 0 ]; then
+        echo "There are commits ahead of origin/main. Push or merge them first."
+        echo "CHANGELOG template needs main commit ID."
+        exit 1
+    fi
+}
+
+echo "=== Checking repository state ==="
+ensure_clean_state
+ensure_full_history
+
+echo ""
+echo "=== Recent commits since last release ==="
+LATEST_TAG=$(git tag --sort=-creatordate | head -1)
+if [ -n "$LATEST_TAG" ]; then
+    git log "$LATEST_TAG"..HEAD --oneline
+else
+    git log --oneline -10
 fi
 
-# bump version
+echo ""
+echo "=== Bumping version ==="
 vim ./Cargo.toml
 
-# update lock file
+VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' ./Cargo.toml | head -n1)
+echo "New version: $VERSION"
+
+echo ""
+echo "=== Updating lock file ==="
 cargo update -p promrail
 
+echo ""
+echo "=== Updating changelog ==="
 just update-changelog
 
+echo ""
+echo "=== Committing release ==="
 git add .
-VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' ./Cargo.toml | head -n1)
 git commit -m "release: Version $VERSION"
 
-echo "After merging the PR, tag and release are automatically done"
+echo ""
+echo "=== Creating release branch and pushing ==="
+git checkout -b "release/v$VERSION"
+git push -u origin "release/v$VERSION"
+
+echo ""
+echo "Release v$VERSION prepared successfully."
+echo "Create a PR to merge release/v$VERSION into main."
+echo "After merge, create and push tag: git tag v$VERSION && git push origin v$VERSION"

--- a/.opencode/skills/release/SKILL.md
+++ b/.opencode/skills/release/SKILL.md
@@ -1,35 +1,47 @@
 ---
 name: release
-description: Guide the release process for promrail, including version bumping, changelog updates, and creating release branches.
+description: Prepare and publish a new release. Use when the user asks to release, cut a release, or publish a new version.
 ---
 
 ## Purpose
 
-Provide step-by-step instructions for releasing a new version of promrail, ensuring proper versioning, changelog updates, and release branch management.
+Release a new version of promrail using the release script and CI pipeline.
 
 ## When to use
 
-Use this skill when asked to:
-- Create a new release
-- Bump the version
-- Prepare a release PR
-- Update the changelog for a release
+Use this skill when:
+- The user asks to release a new version
+- The user asks to cut a release or publish
+- The user asks to tag a new version
 
 ## Prerequisites
 
-Before starting a release:
-1. Ensure you are on the `main` branch
-2. Ensure the working tree is clean (no uncommitted changes)
-3. Ensure local main is up to date with origin/main
+Before releasing, verify:
+
+1. **Working tree is clean** — no uncommitted changes
+2. **You are on `main`** — releases only happen from main
+3. **Local main is up to date with origin/main**
+4. **No commits ahead of origin/main** (output of `git rev-list --count origin/main..HEAD` must be 0)
+5. **Repository is not a shallow clone** — git-cliff needs full history for accurate changelogs
+
+Check with:
+```bash
+git status --short
+git rev-parse --abbrev-ref HEAD
+git pull origin main
+git rev-list --count origin/main..HEAD
+git tag --sort=-creatordate | head -3
+git log --oneline v<latest_tag>..HEAD
+```
 
 ## Version Decision Guide
 
-Use Semantic Versioning (MAJOR.MINOR.PATCH). Determine the bump type by analyzing commits since the last release:
+Use Semantic Versioning (MAJOR.MINOR.PATCH). Determine the bump type by analyzing commits since the last release.
 
 ### Major Version (X.0.0)
 
 Bump MAJOR when:
-- Breaking changes to the CLI interface (removed/renamed commands or flags)
+- Breaking changes to CLI interface or arguments
 - Breaking changes to configuration format
 - Breaking changes to public APIs
 - Commit message contains `BREAKING CHANGE:` or `!` (e.g., `feat!: ...`)
@@ -48,12 +60,11 @@ Bump PATCH when:
 - Bug fixes (`fix:` commits)
 - Documentation updates (`docs:` commits)
 - Internal refactoring (`refactor:` commits)
-- Performance improvements without API changes
-- Dependency updates
+- Dependency updates (`chore(deps):` commits)
 
 ### Decision Process
 
-1. Run: `git log v$(sed -n 's/^version = "\(.*\)"/\1/p' ./Cargo.toml | head -n1)..HEAD --oneline`
+1. Run: `git log v<CURRENT_VERSION>..HEAD --oneline`
 2. Check commit messages for:
    - `!` or `BREAKING CHANGE:` -> MAJOR
    - `feat:` -> MINOR
@@ -64,7 +75,7 @@ Bump PATCH when:
 
 ### Step 1: Verify Clean State
 
-Ensure you're on main with no uncommitted changes and up to date with origin:
+Ensure you're on main with no uncommitted changes, up to date with origin, and no commits ahead:
 
 ```bash
 git checkout main
@@ -72,13 +83,30 @@ git pull origin main
 git status  # Should show "nothing to commit, working tree clean"
 ```
 
-If there are local commits not on origin/main, they must be merged first.
+Verify no commits ahead of origin/main:
+
+```bash
+git rev-list --count origin/main..HEAD  # Should output 0
+```
+
+**Unshallow check** — shallow clones produce incomplete changelogs:
+
+```bash
+git rev-parse --is-shallow-repository
+```
+
+If this outputs `true`, unshallow the repo before proceeding:
+
+```bash
+git fetch --unshallow origin
+git fetch --tags origin
+```
 
 ### Step 2: Determine Version
 
 1. Get current version:
    ```bash
-   cat Cargo.toml | grep '^version ='
+   grep '^version =' Cargo.toml | head -1
    ```
 
 2. Review commits since last release:
@@ -90,27 +118,19 @@ If there are local commits not on origin/main, they must be merged first.
 
 ### Step 3: Create Release Branch
 
-Create a branch named `release/v{NEW_VERSION}`:
-
 ```bash
 git checkout -b release/v<NEW_VERSION>
 ```
 
-Example: `git checkout -b release/v0.3.0`
+### Step 4: Update Version
 
-### Step 4: Update Version in Cargo.toml
-
-Edit `Cargo.toml` and update the version field:
+Edit `Cargo.toml` and update the version:
 
 ```toml
 version = "<NEW_VERSION>"
 ```
 
-The version is on line 7 of Cargo.toml (in the `[package]` section).
-
-### Step 5: Update Cargo.lock
-
-After changing Cargo.toml, update the lock file:
+### Step 5: Update Lock File
 
 ```bash
 cargo update -p promrail
@@ -126,21 +146,15 @@ just update-changelog
 
 This runs: `git cliff -t v<VERSION> -u -p CHANGELOG.md`
 
-The changelog will be automatically updated with commits since the last release, grouped by type (Added, Fixed, Documentation, etc.).
-
 ### Step 7: Commit Changes
-
-Stage and commit all changes:
 
 ```bash
 git add .
-VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' ./Cargo.toml | head -n1)
+VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n1)
 git commit -m "release: Version $VERSION"
 ```
 
 ### Step 8: Push Branch and Create PR
-
-Push the release branch:
 
 ```bash
 git push -u origin release/v<NEW_VERSION>
@@ -150,30 +164,86 @@ Create a pull request to merge into main.
 
 ### Step 9: After Merge
 
-After the PR is merged to main:
-1. Create and push a tag: `git tag v<VERSION> && git push origin v<VERSION>`
-2. The CI workflow automatically builds release artifacts and creates a GitHub Release
+After the PR is merged to main, create and push a tag:
 
-## Quick Reference
+```bash
+git tag v<VERSION> && git push origin v<VERSION>
+```
 
-| Step | Command |
-|------|---------|
-| Check current version | `grep '^version =' Cargo.toml` |
-| View recent commits | `git log v<CUR>..HEAD --oneline` |
-| Create branch | `git checkout -b release/v<VER>` |
-| Update lock file | `cargo update -p promrail` |
-| Update changelog | `just update-changelog` |
-| Commit | `git commit -m "release: Version <VER>"` |
+The CI workflow automatically builds release artifacts and creates a GitHub Release.
+
+## What NOT to Do
+
+| Mistake | Why it's wrong | Fix |
+|---------|---------------|-----|
+| Manually editing CHANGELOG.md | git-cliff generates it from conventional commits | Use `just update-changelog` |
+| Creating git tags manually in CI | Auto-tag workflow may conflict | Follow the process |
+| Releasing from a feature branch | Changelog generation needs main commit IDs | Checkout main first |
+| Releasing with dirty working tree | Script will fail or produce incomplete release | Commit or stash changes first |
+| Skipping the unshallow check | Shallow clones produce incomplete changelogs | Always check and unshallow if needed |
+| Using `--amend` on a commit | May amend the wrong parent commit after hook failures | Just commit again normally |
+
+## Troubleshooting
+
+### "There are commits ahead of origin/main"
+Merge or push them first before starting the release.
+
+### Shallow clone detected
+```bash
+git fetch --unshallow origin
+git fetch --tags origin
+```
+
+### git-cliff not installed
+```bash
+cargo install git-cliff
+```
+
+### Commit failed due to pre-commit hooks
+Do NOT use `--amend`. Simply stage the changes and commit again:
+```bash
+git add .
+git commit -m "release: Version <VERSION>"
+```
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `Cargo.toml` | Package version (single source of truth) |
+| `cliff.toml` | git-cliff configuration for changelog generation |
+| `CHANGELOG.md` | Generated changelog |
+| `.github/workflows/auto-tag.yaml` | Creates signed GPG tag on push to main |
+| `.github/workflows/rust.yml` | Builds, tests, publishes on tag |
+| `.github/workflows/aur-publish.yml` | Publishes AUR packages on tag |
+| `justfile` | `update-changelog` target |
+| `.ci/release.sh` | Full release script |
 
 ## Checklist
 
 - [ ] On main branch, clean working tree
 - [ ] Pulled latest from origin/main
+- [ ] No commits ahead of origin/main
+- [ ] Repository is not a shallow clone (or has been unshallowed)
 - [ ] Determined version bump type (MAJOR/MINOR/PATCH)
 - [ ] Created release branch `release/v<VERSION>`
-- [ ] Updated version in Cargo.toml
+- [ ] Updated version in `Cargo.toml`
 - [ ] Ran `cargo update -p promrail`
 - [ ] Ran `just update-changelog`
 - [ ] Committed with message `release: Version <VERSION>`
-- [ ] Pushed branch and created PR
+- [ ] Pushed and created PR
 - [ ] After merge: created tag `v<VERSION>`
+
+## Quick Reference
+
+| Step | Command |
+|------|---------|
+| Check current version | `grep '^version =' Cargo.toml \| head -1` |
+| View recent commits | `git log v<CUR>..HEAD --oneline` |
+| Check commits ahead | `git rev-list --count origin/main..HEAD` |
+| Check shallow clone | `git rev-parse --is-shallow-repository` |
+| Unshallow repo | `git fetch --unshallow origin && git fetch --tags origin` |
+| Update lock file | `cargo update -p promrail` |
+| Update changelog | `just update-changelog` |
+| Commit | `git commit -m "release: Version <VER>"` |
+| Run release script | `.ci/release.sh` |


### PR DESCRIPTION
## Changes

- Improve `.ci/release.sh` with:
  - Clean state validation (branch, dirty tree, commits ahead)
  - Unshallow detection and full history fetch
  - Automatic release branch creation and push
  - Better output formatting
- Update `.opencode/skills/release/SKILL.md` with:
  - Unshallow prerequisite check
  - Troubleshooting section
  - What NOT to Do table
  - Expanded checklist and quick reference
- Update `.opencode/.gitignore` to include `package-lock.json`